### PR TITLE
Add equation button

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,3 +45,4 @@ The name of the buttons are as follows
 - Ordered List = cmdList0
 - Code = cmdCode
 - Quote = cmdQuote
+- Equation = cmdEquation

--- a/lib/codemwnci/bootstrap-markdown.js
+++ b/lib/codemwnci/bootstrap-markdown.js
@@ -1231,6 +1231,38 @@
             // Set the cursor
             e.setSelection(cursor,cursor+chunk.length)
           }
+        },
+        {
+          name: 'cmdEquation',
+          hotkey: 'Ctrl+E',
+          title: 'Equation',
+          icon: { glyph: 'glyphicon glyphicon-superscript', fa: 'fa fa-superscript', 'fa-3': 'icon-superscript' },
+          callback: function(e) {
+
+            // Give/remove ** surround the selection
+            var chunk, cursor, selected = e.getSelection(), content = e.getContent()
+
+            if (selected.length == 0) {
+              // Give extra word
+              chunk = e.__localize('LaTeX equation here')
+            } else {
+              chunk = selected.text
+            }
+
+            // transform selection and set the cursor into chunked text
+            if (content.substr(selected.start-1,1) == '\\\\['
+                && content.substr(selected.end,1) == '\\\\]' ) {
+              e.setSelection(selected.start+1,selected.end+1)
+              e.replaceSelection(chunk)
+              cursor = selected.start-1
+            } else {
+              e.replaceSelection('\\\\['+chunk+'\\\\]')
+              cursor = selected.start+3
+            }
+
+            // Set the cursor
+            e.setSelection(cursor,cursor+chunk.length)
+          }
         }]
       },{
         name: 'groupUtil',


### PR DESCRIPTION
I have added a new button: equation.

The markdown previewer that I am using supports LaTeX-equation, and it has two equation syntax. One is '\]', '\]'; another is '$$' signs. I prefer '\[' + \]' style for some reasons.

Unfortunately, glyphicons has no equation icon, so I has to choose alternative icon: 'superscript'

If you merge this commit, I want to you choose more suitable icon.

Thanks.
